### PR TITLE
Drop support for v1 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,24 +7,6 @@ updates:
       interval: weekly
     target-branch: master
     groups:
-      devcontainer:
+      github-actions:
         patterns:
           - "*"
-
-  - package-ecosystem: docker
-    directory: /
-    schedule:
-      interval: monthly
-    target-branch: v1
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: monthly
-    target-branch: v1
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: monthly
-    target-branch: v1


### PR DESCRIPTION
Remove all references and configurations related to the v1 branch, streamlining support to the master branch only.